### PR TITLE
Persist config between upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ PSGrafana-build/**
 Build/release-notes.txt
 Build/release-version.txt
 Build/Output
+Build/*.zip
 .DS_Store

--- a/Build/PSGrafana-Template.psm1
+++ b/Build/PSGrafana-Template.psm1
@@ -1,20 +1,25 @@
-If(!(Test-Path $PSScriptRoot\Config\Grafana.json)){
+$PSGrafanaConfigPath = "$ENV:USERPROFILE/.psgrafana"
+If (!(Test-Path $PSGrafanaConfig)) {
+
+    $null = New-Item -Path $PSGrafanaConfigPath -ItemType Directory
+
     $grafanaConfig = @{
         
     }
+    
     Write-Host "No config file found in Config folder. Assuming first run..." -ForegroundColor yellow
     Write-Host "We will now ask some questions to get things setup" -ForegroundColor yellow
     $GrafanaUri = Read-Host -Prompt "What is your base Grafana uri?"
 
     Write-Host "Adding URI and appending /api to config file..." -ForegroundColor yellow
-    $grafanaConfig.Add('GrafanaUri',"$GrafanaUri/api")
+    $grafanaConfig.Add('GrafanaUri', "$GrafanaUri/api")
 
     $ApiKey = Read-Host -Prompt "What is your API Key? Found at https://$GrafanaUri/org/apikeys"
 
     Write-Host "Adding API Key to config file..." -ForegroundColor yellow
-    $grafanaConfig.Add('apikey',$ApiKey)
+    $grafanaConfig.Add('apikey', $ApiKey)
 
-    $grafanaConfig | ConvertTo-Json | Out-File $PSScriptRoot\Config\Grafana.json
+    $grafanaConfig | ConvertTo-Json | Out-File "$PSGrafanaConfigPath/Grafana.json" -Force
 
     Write-Host "Config file has been generated successfully. Run 'Get-GrafanaConfig' to verify" -ForegroundColor yellow
     

--- a/PSGrafana/Public/Get-GrafanaConfig.ps1
+++ b/PSGrafana/Public/Get-GrafanaConfig.ps1
@@ -18,7 +18,7 @@ function Get-GrafanaConfig {
         [Parameter(Position=0)]
         [String]
 
-        $ConfigurationFile = "$PSScriptRoot\Config\Grafana.json"
+        $ConfigurationFile = "$ENV:USERPROFILE/.psgrafana/Grafana.json"
 
     )
 

--- a/PSGrafana/Public/Set-GrafanaConfig.ps1
+++ b/PSGrafana/Public/Set-GrafanaConfig.ps1
@@ -20,7 +20,7 @@ function Set-GrafanaConfig {
     Param(
         [Parameter()]
         [String]
-        $ConfigurationFile = "$PSScriptRoot\Config\Grafana.json",
+        $ConfigurationFile = "$ENV:USERPROFILE/.psgrafana/Grafana.json",
 
         [Parameter()]
         [String]

--- a/PSGrafana/README.md
+++ b/PSGrafana/README.md
@@ -1,0 +1,80 @@
+<p align="center"><img src="https://github.com/steviecoaster/PSGrafana/wiki/Assets/PSGrafana.png" width=100></p>
+
+# PSGrafana
+
+The PSGrafana module is a PowerShell wrapper around the Grafana API. Grafana uses this API internally for everything you do in the web interface. It made sense to create a wrapper such that you could bolt Grafana tasks to any automation pipelines one might have in their organizations.
+
+## Status
+
+The module is currently in development, and as such expect rapid changes, specifically on the `develop` branch. The master branch will only contain code that has been deemed "working" and triggers the pipeline to publish new module versions.
+
+---
+
+## Contributing
+
+If you would like to help out, please target the `develop` branch when creating pull requests, otherwise the pipeline will have a bad time and we'll end up with stuff hitting the gallery too early.
+
+---
+
+## Currently available functions include:
+
+- Get-GrafanaConfig
+- Set-GrafanaConfig
+- Get-GrafanaDashboard
+- New-GrafanaDashboard
+- Set-GrafanaDashboard
+- Remove-GrafanaDashboard
+- Get-GrafanaServerHealth
+- Get-GrafanaApiKey
+- Get-GrafanaDatasource
+- Remove-GrafanaDatasource
+- Remove-GrafanaApiKey
+- New-GrafanaApiKey
+- New-GrafanaSnapshot
+- Get-GrafanaSnapshot
+- Remove-GrafanaSnapshot
+- Get-GrafanaAlert
+- Suspend-GrafanaAlert
+- New-GrafanaFolder
+- Get-GrafanaFolder
+- Remove-GrafanaFolder
+
+---
+
+## Installation
+
+#### Github:
+
+Option 1:
+
+Clone this repository. Import the psd1 file from the directory with `Import-module ./PSGrafana.psd1` or the full path to the psd1 file if outside the cloned directory.
+
+Option 2:
+
+Clone the repository somewhere in your $PSModulePath, and then run `Import-Module PSGrafana`
+
+Option 3: 
+
+Download the zip archive and extract it on your machine and reference Option 1 or 2 above based on where you extract it too.
+
+#### Powershell Gallery
+
+This module is available via the Powershell Gallery. The latest released version is v0.0.4. 
+
+To install simply run `Install-Module PSGrafana`
+
+_IMPORTANT NOTE REGARDING INSTALLATION:_
+
+Upon first run, a configuration file will be generated for you by asking a series of questions. Namely:
+
+- What is your Grafana instance URL?
+- What is your Grafana instance API key?
+
+Once provided a Grafana.json file will be generated in your user profile in the `.psgrafana` directory. All functions pull in this configuration in their `begin {}` blocks to reference the global $configuration variable.
+
+---
+
+## Issues?
+
+Did you find a bug? Awesome! I wanna know about it. Please file an issue providing as much information as possible.
+Did you find a bug, _and_ fix the bug? Awesome! Thanks so much! Please file the detailed issue, and submit a PR for review. Be sure to add 'Fixes _issue\_number_' at the bottom of the PR notes so the Issue can be closed automatically upon merge, and the history shows in both.


### PR DESCRIPTION
This PR persists Grafana config in the users profile directory

```
$ENV:USER_PROFILE/.psgrafana/Grafana.json
```
Changes:
- Updated readme
- Removed module Config directory
- Updated PSM1 template
- Updated Get-GrafanaConfig
- Updated Set-GrafanaConfig 

Fixes #10 